### PR TITLE
Added support for .NET Core 2.1

### DIFF
--- a/RazorEngine.NetCore/RazorEngine.NetCore.csproj
+++ b/RazorEngine.NetCore/RazorEngine.NetCore.csproj
@@ -21,7 +21,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/fouadmess/RazorEngine</RepositoryUrl>
     <PackageProjectUrl>https://github.com/fouadmess/RazorEngine</PackageProjectUrl>
-    <Version>2.2.3</Version>
+    <Version>2.2.4</Version>
     <Copyright>RazorEngine Copyright © RazorEngine Project 2011-2018</Copyright>
     <Company>RazorEngine</Company>
     <Product>RazorEngine</Product>
@@ -33,9 +33,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor" Version="[2.1.0, 2.2)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="[2.1.0, 2.2)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="[2.1.0, 2.2)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.2.0" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.2.0" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
 
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />

--- a/RazorEngine.NetCore/RazorEngine.NetCore.csproj
+++ b/RazorEngine.NetCore/RazorEngine.NetCore.csproj
@@ -30,9 +30,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="[2.1.0, 2.2)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="[2.1.0, 2.2)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="[2.1.0, 2.2)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.2.0" />

--- a/RazorEngine.NetCore/RazorEngine.NetCore.csproj
+++ b/RazorEngine.NetCore/RazorEngine.NetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);RAZOR4</DefineConstants>
     <DefineConstants>$(DefineConstants);NO_APPDOMAIN;NO_CODEDOM;NO_CONFIGURATION;NETCORE</DefineConstants>
   </PropertyGroup>
@@ -21,7 +21,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/fouadmess/RazorEngine</RepositoryUrl>
     <PackageProjectUrl>https://github.com/fouadmess/RazorEngine</PackageProjectUrl>
-    <Version>2.2.2</Version>
+    <Version>2.2.3</Version>
     <Copyright>RazorEngine Copyright © RazorEngine Project 2011-2018</Copyright>
     <Company>RazorEngine</Company>
     <Product>RazorEngine</Product>
@@ -30,9 +30,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.2.0" />
+
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />


### PR DESCRIPTION
Hello, 

while I tried to add this NuGet package to a .NET Core 2.1 project, I got an error about a conflicting version for `Microsoft.AspNetCore.Html.Abstractions`. When working with 2.1, that package (and similar ones) should be limited to minor version 1, so version 2.2.0 is not ok. 

I've defined a target for netcoreapp2.1, and added dependecies locked to that target that reference certain packages to a version between 2.1.0 (inclusive) and 2.2 (exclusive). 

I've already tried locally the fix, and it works. I also took the liberty to bump up the version number. 

Let me know if I have to make some changes. 