### PR TITLE
Add support for debugging in .NET core on Linux and OSX

### DIFF
--- a/RazorEngine.NetCore/Compilation/RoslynCompilerServiceBase.cs
+++ b/RazorEngine.NetCore/Compilation/RoslynCompilerServiceBase.cs
@@ -16,6 +16,7 @@ using System.Web.Razor;
 using Microsoft.CodeAnalysis.Text;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Permissions;
 using Microsoft.CodeAnalysis.Emit;
@@ -191,6 +192,16 @@ namespace RazorEngine.Roslyn.CSharp
         }
 
         /// <summary>
+        /// Check for if we're on Linux as Roslyn needs to generate portable PDBs for
+        /// proper execution on Mono/Unix.
+        /// </summary>
+        /// <returns></returns>
+        private static bool IsLinux()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        }
+
+        /// <summary>
         /// Configures and runs the compiler.
         /// </summary>
         /// <param name="context"></param>
@@ -235,7 +246,7 @@ namespace RazorEngine.Roslyn.CSharp
                     .WithPdbFilePath(assemblyPdbFile);
                 var pdbStreamHelper = pdbStream;
 
-                if (IsMono())
+                if (IsMono() || IsLinux())
                 {
                     opts = opts.WithDebugInformationFormat(DebugInformationFormat.PortablePdb);
                 }

--- a/RazorEngine.NetCore/Compilation/RoslynCompilerServiceBase.cs
+++ b/RazorEngine.NetCore/Compilation/RoslynCompilerServiceBase.cs
@@ -186,19 +186,11 @@ namespace RazorEngine.Roslyn.CSharp
         /// proper execution on Mono/Unix.
         /// </summary>
         /// <returns></returns>
-        private static bool IsMono()
+        private static bool ShouldCreatePortablePdb()
         {
-            return Type.GetType("Mono.Runtime") != null;
-        }
-
-        /// <summary>
-        /// Check for if we're on Linux as Roslyn needs to generate portable PDBs for
-        /// proper execution on Mono/Unix.
-        /// </summary>
-        /// <returns></returns>
-        private static bool IsLinux()
-        {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            return Type.GetType("Mono.Runtime") != null
+                || RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         }
 
         /// <summary>
@@ -246,7 +238,7 @@ namespace RazorEngine.Roslyn.CSharp
                     .WithPdbFilePath(assemblyPdbFile);
                 var pdbStreamHelper = pdbStream;
 
-                if (IsMono() || IsLinux())
+                if (ShouldCreatePortablePdb())
                 {
                     opts = opts.WithDebugInformationFormat(DebugInformationFormat.PortablePdb);
                 }


### PR DESCRIPTION
In .NET core on Linux, when debugging, I receive the following exception:

`Unexpected error writing debug information -- 'COM Interop is not supported on this platform.'`

The reason for this is that the debug information is not created in PortablePdb format. This PR solves this.