### PR TITLE
Fix invalidating cache in the WatchingResolvePathTemplateManager when the source teplate file is renaming

### DIFF
--- a/RazorEngine.NetCore/Templating/WatchingResolvePathTemplateManager.cs
+++ b/RazorEngine.NetCore/Templating/WatchingResolvePathTemplateManager.cs
@@ -77,14 +77,19 @@ namespace RazorEngine.Templating
 
         void watcher_Changed(object sender, FileSystemEventArgs e)
         {
-            cache.InvalidateCache(new FullPathTemplateKey(e.Name, e.FullPath, ResolveType.Global, null));
+            InvalidateTemplateCache(e.Name, e.FullPath);
             //queue.Enqueue(e);
         }
 
         void watcher_Renamed(object sender, RenamedEventArgs e)
         {
-            watcher_Changed(sender, new FileSystemEventArgs(WatcherChangeTypes.Deleted, e.OldFullPath, e.OldName));
-            watcher_Changed(sender, new FileSystemEventArgs(WatcherChangeTypes.Created, e.FullPath, e.Name));
+            InvalidateTemplateCache(e.OldName, e.OldFullPath);
+            InvalidateTemplateCache(e.Name, e.FullPath);
+        }
+
+        private void InvalidateTemplateCache(string name, string fullPath)
+        {
+            cache.InvalidateCache(new FullPathTemplateKey(name, fullPath, ResolveType.Global, null));
         }
 
         /// <summary>


### PR DESCRIPTION
I'm using WatchingResolvePathTemplateManager to simplify template creation at the development time leveraging change-and-check iterative process without restarting my application.

When trying to change source template file in the Visual Studio it appears that template cache is not invalidating, while with changes in simple text editor everything works fine. The reason is Visual Studion makes files changes by creating temporal files and renaming them to editing ones after all.

In WatchingResolvePathTemplateManager files renamings was handled with emulating two other events: delete file and create file. The issue was in using FileSystemEventArgs constructor calling which accepts file directory as a second argument. But the full path of the file was passed to it. This causes wrong template file invalidating.

I fixed it by explicitly calling invalidating function for "deleted" and "created" files in "file renamed" event handler.